### PR TITLE
Center forms on left hand side

### DIFF
--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,7 +1,12 @@
 const layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <main className="p-4">
-      <section>{children}</section>
+    <main className="flex flex-row">
+      <section className="flex w-1/2">
+        {children}
+      </section>
+      <div className="w-1/2">
+        <p>*photo goes here*</p>
+      </div>
     </main>
   );
 };

--- a/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -2,13 +2,13 @@ import Link from "next/link";
 
 const LoginForm = () => {
   return (
-    <form className="outline w-[27.5rem] p-14 text-center rounded-xl">
+    <form className="bg-white outline w-[27.5rem] p-14 text-center rounded-xl ">
       <h1 className="font-bold text-3xl mb-5">Welcome Back!</h1>
       <div className="flex flex-col gap-3 justify-center items-center">
         <input className="outline p-2 rounded-xl w-full mb-2" placeholder="Username" type="text" required />
         <input className="outline p-2 rounded-xl w-full mb-2" placeholder="Password" type="password" required />
 
-        <button className="bg-emerald-400 rounded-3xl w-32 p-2">Log In</button>
+        <button className="bg-emerald-400 rounded-3xl w-32 p-2 font-bold">Log In</button>
         <div className=" flex flex-row justify-center gap-1">
             <p>Don't have an account?</p>
             <Link href="/signup" className="text-blue-500 font-bold">Sign Up</Link>       

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@ import LoginForm from './LoginForm';
 
 const Login = () => {
   return (
-    <main>
+    <main className="flex min-h-screen justify-center items-center w-full">
       <LoginForm />
     </main>
   )

--- a/frontend/src/app/(auth)/signup/SignUpForm.tsx
+++ b/frontend/src/app/(auth)/signup/SignUpForm.tsx
@@ -1,8 +1,9 @@
+import Link from 'next/link'
 import React from 'react'
 
 const SignUpForm = () => {
   return (
-    <form className='outline w-[29rem] p-14 text-center rounded-xl'>
+    <form className='bg-white outline w-[29rem] p-14 text-center rounded-xl'>
         <h1 className='text-2xl font-bold mb-2'>Welcome to (Our store name)!</h1>
         <h2 className='text-xl font-bold mb-10'>Sign Up Start Shopping</h2>
         <div className='flex flex-col items-center'>
@@ -11,8 +12,11 @@ const SignUpForm = () => {
             <input className='outline p-2 rounded-xl w-full mb-3'placeholder='Username' type ="text" required/>
             <input className='outline p-2 rounded-xl w-full mb-3'placeholder='Password' type='password' required/>
             <input className='outline p-2 rounded-xl w-full mb-5' placeholder='Confirm Password' type="password" required/>
-
             <button className='rounded-3xl font-bold bg-emerald-400 w-32 p-2'>Sign Up</button>
+            <div className=" flex flex-row justify-center gap-1">
+            <p>Already have an account?</p>
+            <Link href="/login" className="text-blue-500 font-bold">Log In</Link>       
+        </div>
         </div>
     </form>
   )

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -3,7 +3,9 @@ import SignUpForm from './SignUpForm';
 
 const Signup = () => {
   return (
-    <main><SignUpForm/></main>
+    <main className="flex min-h-screen justify-center items-center w-full">
+      <SignUpForm/>
+    </main>
   )
 }
 


### PR DESCRIPTION
Both the signup and login forms were on the upper left corner of the screens. Moved them to the center on the left hand side. Added a container on the right hand side to app images.

Before:
<img width="1679" alt="Screenshot 2024-11-11 at 12 42 33 AM" src="https://github.com/user-attachments/assets/71022dcd-33a2-4505-a5e5-6e2485e1e266">

After:
<img width="1678" alt="Screenshot 2024-11-11 at 12 42 47 AM" src="https://github.com/user-attachments/assets/e1835f2b-39f2-441c-861a-a38dd7e6b87f">

