### PR TITLE
Fix flip color from black to emerald.

### DIFF
--- a/frontend/src/components/ui/FlipWords.tsx
+++ b/frontend/src/components/ui/FlipWords.tsx
@@ -57,7 +57,7 @@ export const FlipWords = ({
           position: "absolute",
         }}
         className={cn(
-          "z-10 inline-block relative text-left text-neutral-900 dark:text-emerald-400 px-2",
+          "z-10 inline-block relative text-left text-emerald-400 dark:text-emerald-400 px-2",
           className
         )}
         key={currentWord}


### PR DESCRIPTION
Changes made
In this pull request I am changing the fliping words color from black to emerald in the login and sign up pages. 