### PR TITLE
Fixed Functionality of Cart Classes (NEED SQL PERMISSIONS CHANGED)

### DIFF
--- a/backend/CombinedAPI/Controllers/CartController.cs
+++ b/backend/CombinedAPI/Controllers/CartController.cs
@@ -20,12 +20,12 @@ namespace CombinedAPI.Controllers
       _cartManager = cartManager;
     }
 
-    // GET: api/cart/get-cart/{cartId}
-    [HttpGet("get-cart/{cartId}")]
-    public IActionResult getUserCart(int cartId)
+    // GET: api/cart/get-cart/{userId}
+    [HttpGet("get-cart/{userId}")]
+    public IActionResult getUserCart(int userId)
     {
-      Console.WriteLine($"Getting Cart by ID : {cartId}");
-      var cart = _cartManager.getUserCart(cartId);
+      Console.WriteLine($"Getting Cart by User ID : {userId}");
+      var cart = _cartManager.getUserCart(userId);
       if (cart == null)
       {
         Console.WriteLine("Unable to locate Cart.");
@@ -34,10 +34,10 @@ namespace CombinedAPI.Controllers
     }
 
     // GET: api/cart/cartId/product/amount
-    [HttpGet("/cart/{cartId}/{product}/{amount}")]
-    public IActionResult addToCart(int cartId, Product product, int amount)
+    [HttpPost("/cart/{userId}/{productId}/{amount}")]
+    public IActionResult addToCart(int cartId, int productId, int amount)
     {
-      bool success = _cartManager.addToCart(cartId, product, amount);
+      bool success = _cartManager.addToCart(cartId, productId, amount);
       if (!success)
       {
         Console.WriteLine("Unable to add to cart");
@@ -47,10 +47,10 @@ namespace CombinedAPI.Controllers
 
     // GET: api/cart/cartId
     // GET: api/product
-    [HttpGet("cart/{cartId}/{product}")]
-    public IActionResult removeFromCart(int cartId, Product product)
+    [HttpDelete("cart/{userId}/{productId}")]
+    public IActionResult removeFromCart(int userId, int productId)
     {
-      bool success = _cartManager.removeFromCart(cartId, product);
+      bool success = _cartManager.removeFromCart(userId, productId);
       if (!success)
       {
         Console.WriteLine("Unable to remove from cart");
@@ -61,10 +61,10 @@ namespace CombinedAPI.Controllers
     // GET: api/cart/cartId
     // GET: api/product
     // GET: api/cart/amount
-    [HttpGet("cart/{cartId}/{product}/{amount}")]
-    public IActionResult updateAmount(int cartId, Product product, int amount)
+    [HttpPut("cart/{userId}/{productId}/{amount}")]
+    public IActionResult updateAmount(int userId, int productId, int amount)
     {
-      bool success = _cartManager.updateAmount(cartId, product, amount);
+      bool success = _cartManager.updateAmount(userId, productId, amount);
       if (!success)
       {
         Console.WriteLine("Unable to update amount in cart");
@@ -73,9 +73,17 @@ namespace CombinedAPI.Controllers
     }
 
     // GET: api/cart/initiate-cart
-    [HttpGet("initiate-cart/{cart}")]
-    public IActionResult initiateCart(Cart cart)
+    [HttpPost("initiate-cart/{userId}/{productId}/{amount}")]
+    public IActionResult initiateCart(int userId, int productId, int amount, double price)
     {
+      SortedDictionary<int, int> itemList = new SortedDictionary<int, int>();
+      itemList.Add(productId, amount);
+      Cart cart = new Cart
+      {
+         userId = userId,
+         totalPrice = 0,
+         itemList = itemList
+      };
       bool success = _cartManager.initiateCart(cart);
       if (!success)
       {
@@ -85,10 +93,10 @@ namespace CombinedAPI.Controllers
     }
 
     // GET: api/cart/clear/cartId
-    [HttpGet("cart/clear/{cartId}")]
-    public IActionResult clearCart(int cartId)
+    [HttpDelete("cart/clear/{userId}")]
+    public IActionResult clearCart(int userId)
     {
-      bool success = _cartManager.clearCart(cartId);
+      bool success = _cartManager.clearCart(userId);
       if (!success)
       {
         Console.WriteLine("Unable to clear cart");

--- a/backend/CombinedAPI/Interfaces/ICartAccessor.cs
+++ b/backend/CombinedAPI/Interfaces/ICartAccessor.cs
@@ -4,11 +4,11 @@ namespace CombinedAPI.Interfaces
 {
   public interface ICartAccessor
   {
-    public Cart getUserCart(int cartId);
-    bool addToCart(int cartId, Product product, int amount);
-    bool removeFromCart(int cartId, Product product);
-    bool updateAmount(int cartId, Product product, int amount);
-    bool initiateCart(Cart cart);
-    bool clearCart(int cartId);
-  }
+        Cart getUserCart(int userId);
+        bool addToCart(int userId, int product, int amount);
+        bool removeFromCart(int userId, int product);
+        bool updateAmount(int userId, int product, int amount);
+        bool initiateCart(Cart cart);
+        bool clearCart(int userId);
+    }
 }

--- a/backend/CombinedAPI/Interfaces/ICartEngine.cs
+++ b/backend/CombinedAPI/Interfaces/ICartEngine.cs
@@ -4,11 +4,11 @@ namespace CombinedAPI.Interfaces
 {
   public interface ICartEngine
   {
-    Cart getUserCart(int cartId);
-    bool addToCart(int cartId, Product product, int amount);
-    bool removeFromCart(int cartId, Product product);
-    bool updateAmount(int cartId, Product product, int amount);
-    bool initiateCart(Cart cart);
-    bool clearCart(int cartId);
-  }
+        Cart getUserCart(int userId);
+        bool addToCart(int userId, int product, int amount);
+        bool removeFromCart(int userId, int product);
+        bool updateAmount(int userId, int product, int amount);
+        bool initiateCart(Cart cart);
+        bool clearCart(int userId);
+    }
 }

--- a/backend/CombinedAPI/Interfaces/ICartManager.cs
+++ b/backend/CombinedAPI/Interfaces/ICartManager.cs
@@ -4,11 +4,11 @@ namespace CombinedAPI.Interfaces
 {
   public interface ICartManager
   {
-    Cart getUserCart(int cartId);
-    bool addToCart(int cartId, Product product, int amount);
-    bool removeFromCart(int cartId, Product product);
-    bool updateAmount(int cartId, Product product, int amount);
+    Cart getUserCart(int userId);
+    bool addToCart(int userId, int product, int amount);
+    bool removeFromCart(int userId, int product);
+    bool updateAmount(int userId, int product, int amount);
     bool initiateCart(Cart cart);
-    bool clearCart(int cartId);
+    bool clearCart(int userId);
   }
 }

--- a/backend/CombinedAPI/Interfaces/ICartRepository.cs
+++ b/backend/CombinedAPI/Interfaces/ICartRepository.cs
@@ -4,11 +4,11 @@ namespace CombinedAPI.Interfaces
 {
   public interface ICartRepository
   {
-    Cart getUserCart(int cartId);
-    bool addToCart(int cartId, Product product, int amount);
-    bool removeFromCart(int cartId, Product product);
-    bool updateAmount(int cartId, Product product, int amount);
+    Cart getUserCart(int userId);
+    bool addToCart(int userId, int product, int amount);
+    bool removeFromCart(int userId, int product);
+    bool updateAmount(int userId, int product, int amount);
     bool initiateCart(Cart cart);
-    bool clearCart(int cartId);
-  }
+    bool clearCart(int userId);
+    }
 }

--- a/backend/CombinedAPI/Models/Cart.cs
+++ b/backend/CombinedAPI/Models/Cart.cs
@@ -2,7 +2,7 @@ namespace CombinedAPI.Models
 {
   public class Cart
   {
-    public required int cartId { get; set; }
+    public int cartId { get; set; }
     public required int userId { get; set; }
     public required SortedDictionary<int, int> itemList { get; set; }
     public required double totalPrice { get; set; }

--- a/backend/CombinedAPI/Repositories/CartAccessor.cs
+++ b/backend/CombinedAPI/Repositories/CartAccessor.cs
@@ -12,42 +12,42 @@ namespace CombinedAPI.Repositories
       _cartRepository = cartRepository;
     }
 
-    public Cart getUserCart(int cartId)
+    public Cart getUserCart(int userId)
     {
-      return _cartRepository.getUserCart(cartId);
+      return _cartRepository.getUserCart(userId);
     }
 
-    public bool addToCart(int cartId, Product product, int amount)
+    public bool addToCart(int userId, int productId, int amount)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.addToCart(cartId, product, amount);
+      return _cartRepository.addToCart(userId, productId, amount);
     }
 
-    public bool removeFromCart(int cartId, Product product)
+    public bool removeFromCart(int userId, int productId)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.removeFromCart(cartId, product);
+      return _cartRepository.removeFromCart(userId, productId);
     }
 
-    public bool updateAmount(int cartId, Product product, int amount)
+    public bool updateAmount(int userId, int productId, int amount)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.updateAmount(cartId, product, amount);
+      return _cartRepository.updateAmount(userId, productId, amount);
     }
 
     public bool initiateCart(Cart cart)
@@ -55,15 +55,15 @@ namespace CombinedAPI.Repositories
       return _cartRepository.initiateCart(cart);
     }
 
-    public bool clearCart(int cartId)
+    public bool clearCart(int userId)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.clearCart(cartId);
+      return _cartRepository.clearCart(userId);
 
     }
   }

--- a/backend/CombinedAPI/Repositories/CartRepository.cs
+++ b/backend/CombinedAPI/Repositories/CartRepository.cs
@@ -15,7 +15,7 @@ namespace CombinedAPI.Repositories
       _connectionString = connectionString;
     }
 
-    public Cart getUserCart(int cartId)
+    public Cart getUserCart(int userId)
     {
       SortedDictionary<int, int> tempItemList = new SortedDictionary<int, int>();
 
@@ -33,20 +33,20 @@ namespace CombinedAPI.Repositories
       {
         connection.Open();
 
-        string query = "SELECT * FROM Cart WHERE CartId = @CartId";
+        string query = "SELECT * FROM CheckoutCart WHERE userID = @userID";
         using (SqlCommand cmd = new SqlCommand(query, connection))
         {
-          cmd.Parameters.AddWithValue("@CartId", cartId);
+          cmd.Parameters.AddWithValue("@userID", userId);
           using (SqlDataReader reader = cmd.ExecuteReader())
           {
             while (reader.Read())
             {
-              cart.cartId = reader.GetInt32(reader.GetOrdinal("CartId"));
-              cart.userId = reader.GetInt32(reader.GetOrdinal("UserId"));
+              cart.cartId = reader.GetInt32(reader.GetOrdinal("cartID"));
+              cart.userId = reader.GetInt32(reader.GetOrdinal("userID"));
 
-              int productId = reader.GetInt32(reader.GetOrdinal("ProductId"));
-              int amount = reader.GetInt32(reader.GetOrdinal("Amount"));
-              double price = reader.GetDouble(reader.GetOrdinal("Price"));
+              int productId = reader.GetInt32(reader.GetOrdinal("productID"));
+              int amount = reader.GetInt32(reader.GetOrdinal("quantity"));
+              double price = getCost(productId, amount);
 
               tempItemList[productId] = amount;
               tempPrice += price;
@@ -63,20 +63,39 @@ namespace CombinedAPI.Repositories
 
 
 
-    public bool addToCart(int cartId, Product product, int amount)
+    public bool addToCart(int userId, int productId, int amount)
     {
-      Cart tempCart = getUserCart(cartId);
+      Cart tempCart = getUserCart(userId);
+      if (tempCart.itemList.ContainsKey(productId))
+      {
+        return updateAmount(userId, productId, (tempCart.itemList[productId] + amount));
+      }
       using (SqlConnection connection = new SqlConnection(_connectionString))
       {
         connection.Open();
-        string query = "INSERT INTO Cart (CartId, UserId, ProductID, Amount, Price) VALUES(@CartId, @UserId, @ProductID, @Amount, @Price)";
+        string query = "INSERT INTO CheckoutCart (cartID, userID, productID, quantity) VALUES(@cartID, @userID, @productID, @quantity)";
         using (SqlCommand cmd = new SqlCommand(query, connection))
         {
-          cmd.Parameters.AddWithValue("@CartId", cartId);
-          cmd.Parameters.AddWithValue("@UserId", tempCart.userId);
-          cmd.Parameters.AddWithValue("@ProductID", product.ProductID);
-          cmd.Parameters.AddWithValue("@Amount", amount);
-          cmd.Parameters.AddWithValue("@Price", product.Price * amount);
+          cmd.Parameters.AddWithValue("@cartID", tempCart.cartId);
+          cmd.Parameters.AddWithValue("@userID", userId);
+          cmd.Parameters.AddWithValue("@productID", productId);
+          cmd.Parameters.AddWithValue("@quantity", amount);
+          int rowsAffected = cmd.ExecuteNonQuery();
+          return rowsAffected > 0;
+        }
+      }
+    }
+
+    public bool removeFromCart(int userId, int productId)
+    {
+      using (SqlConnection connection = new SqlConnection(_connectionString))
+      {
+        connection.Open();
+        string query = "DELETE FROM CheckoutCart WHERE userID = @userID AND productID = @productID";
+        using (SqlCommand cmd = new SqlCommand(query, connection))
+        {
+          cmd.Parameters.AddWithValue("@userID", userId);
+          cmd.Parameters.AddWithValue("@productID", productId);
 
           int rowsAffected = cmd.ExecuteNonQuery();
           return rowsAffected > 0;
@@ -84,34 +103,17 @@ namespace CombinedAPI.Repositories
       }
     }
 
-    public bool removeFromCart(int cartId, Product product)
+    public bool updateAmount(int userId, int productId, int amount)
     {
       using (SqlConnection connection = new SqlConnection(_connectionString))
       {
         connection.Open();
-        string query = "DELETE FROM Cart WHERE CartId = @CartId AND ProductId = @ProductId";
+        var query = "UPDATE CheckoutCart SET quantity = @quantity WHERE userID = @userID AND productID = @productID";
         using (SqlCommand cmd = new SqlCommand(query, connection))
         {
-          cmd.Parameters.AddWithValue("@CartId", cartId);
-          cmd.Parameters.AddWithValue("@ProductId", product.ProductID);
-
-          int rowsAffected = cmd.ExecuteNonQuery();
-          return rowsAffected > 0;
-        }
-      }
-    }
-
-    public bool updateAmount(int cartId, Product product, int amount)
-    {
-      using (SqlConnection connection = new SqlConnection(_connectionString))
-      {
-        connection.Open();
-        var query = "UPDATE Cart SET Amount = @Amount WHERE CartId = @CartId AND ProductID = @ProductID";
-        using (SqlCommand cmd = new SqlCommand(query, connection))
-        {
-          cmd.Parameters.AddWithValue("@Amount", amount);
-          cmd.Parameters.AddWithValue("@CartId", cartId);
-          cmd.Parameters.AddWithValue("@ProductID", product.ProductID);
+          cmd.Parameters.AddWithValue("@quantity", amount);
+          cmd.Parameters.AddWithValue("@userID", userId);
+          cmd.Parameters.AddWithValue("@productID", productId);
 
           int rowsAffected = cmd.ExecuteNonQuery();
           return rowsAffected > 0;
@@ -126,10 +128,15 @@ namespace CombinedAPI.Repositories
         throw new InvalidOperationException("Cannot create new cart instance with more or less than one product.");
       }
 
+      if (getUserCart(cart.userId) == null)
+      {
+        throw new InvalidOperationException("User already has a cart.");
+      }
+
       using (SqlConnection connection = new SqlConnection(_connectionString))
       {
         connection.Open();
-        string query = @"INSERT INTO Cart (UserId, ProductID, Amount, Price) VALUES(@UserId, @ProductID, @Amount, @Price)";
+        string query = @"INSERT INTO CheckoutCart (userID, productID, quantity) VALUES(@userID, @productID, @quantity)";
         using (SqlCommand cmd = new SqlCommand(query, connection))
         {
           var productId = cart.itemList.First().Key;
@@ -138,10 +145,9 @@ namespace CombinedAPI.Repositories
           ProductRepository productRepo = new ProductRepository(_connectionString);
           Product product = productRepo.GetProductById(productId);
 
-          cmd.Parameters.AddWithValue("@UserId", cart.userId);
-          cmd.Parameters.AddWithValue("@ProductID", product.ProductID);
-          cmd.Parameters.AddWithValue("@Amount", amount);
-          cmd.Parameters.AddWithValue("@Price", product.Price * amount);
+          cmd.Parameters.AddWithValue("@userID", cart.userId);
+          cmd.Parameters.AddWithValue("@productID", product.ProductID);
+          cmd.Parameters.AddWithValue("@quantity", amount);
 
 
           int rowsAffected = cmd.ExecuteNonQuery();
@@ -150,19 +156,60 @@ namespace CombinedAPI.Repositories
       }
     }
 
-    public bool clearCart(int cartId)
+    public bool clearCart(int userId)
     {
       using (var connection = new SqlConnection(_connectionString))
       {
         connection.Open();
-        var query = "DELETE FROM Cart WHERE CartId = @CartId";
+        var query = "DELETE FROM CheckoutCart WHERE userID = @userID";
         using (SqlCommand cmd = new SqlCommand(query, connection))
         {
-          cmd.Parameters.AddWithValue("@CartId", cartId);
+          cmd.Parameters.AddWithValue("@userID", userId);
           int rowsAffected = cmd.ExecuteNonQuery();
           return rowsAffected > 0;
         }
       }
     }
+
+    private double getCost(int productId, int amount)
+        {
+            double cost = 0;
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                connection.Open();
+                string query = @"
+              SELECT 
+                  p.ProductID,
+                  p.Name,
+                  p.Description,
+                  p.Price,
+                  COALESCE(
+                      CASE 
+                          WHEN s.IsPercentage = 1 THEN p.Price * (1 - s.DiscountAmount / 100.0)
+                          ELSE p.Price - s.DiscountAmount
+                      END,
+                      p.Price
+                  ) AS DiscountedPrice
+              FROM 
+                  Products p
+              LEFT JOIN 
+                  Sales s ON p.SaleID = s.SaleID AND s.StartDate <= GETDATE() AND GETDATE() <= s.EndDate
+              WHERE 
+                  p.productID = @productID;";
+                using (SqlCommand cmd = new SqlCommand(query, connection))
+                {
+                    cmd.Parameters.AddWithValue("@productID", productId);
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                    {
+                        if (reader.Read())
+                        {
+                            cost = (double)reader.GetDecimal(reader.GetOrdinal("Price"));
+                        }
+                        cost = cost * amount;
+                    }
+                }
+            }
+            return cost;
+        }
   }
 }

--- a/backend/CombinedAPI/Services/CartEngine.cs
+++ b/backend/CombinedAPI/Services/CartEngine.cs
@@ -13,47 +13,47 @@ namespace CombinedAPI.Services
       _cartRepository = cartRepository;
     }
 
-    public Cart getUserCart(int cartId)
+    public Cart getUserCart(int userId)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with user ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
       return cart;
     }
 
-    public bool addToCart(int cartId, Product product, int amount)
+    public bool addToCart(int userId, int product, int amount)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.addToCart(cartId, product, amount);
+      return _cartRepository.addToCart(userId, product, amount);
     }
 
-    public bool removeFromCart(int cartId, Product product)
+    public bool removeFromCart(int userId, int product)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.removeFromCart(cartId, product);
+      return _cartRepository.removeFromCart(userId, product);
     }
 
-    public bool updateAmount(int cartId, Product product, int amount)
+    public bool updateAmount(int userId, int productId, int amount)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.updateAmount(cartId, product, amount);
+      return _cartRepository.updateAmount(userId, productId, amount);
     }
 
     public bool initiateCart(Cart cart)
@@ -61,15 +61,15 @@ namespace CombinedAPI.Services
       return _cartRepository.initiateCart(cart);
     }
 
-    public bool clearCart(int cartId)
+    public bool clearCart(int userId)
     {
-      var cart = _cartRepository.getUserCart(cartId);
+      var cart = _cartRepository.getUserCart(userId);
       if (cart == null)
       {
-        throw new ArgumentException($"No cart found with ID {cartId}");
+        throw new ArgumentException($"No cart found with User ID {userId}");
       }
 
-      return _cartRepository.clearCart(cartId);
+      return _cartRepository.clearCart(userId);
     }
   }
 }

--- a/backend/CombinedAPI/Services/CartManager.cs
+++ b/backend/CombinedAPI/Services/CartManager.cs
@@ -13,24 +13,24 @@ namespace CombinedAPI.Services
       _cartEngine = cartEngine;
     }
 
-    public Cart getUserCart(int cartId)
+    public Cart getUserCart(int userId)
     {
-      return _cartEngine.getUserCart(cartId);
+      return _cartEngine.getUserCart(userId);
     }
 
-    public bool addToCart(int cartId, Product product, int amount)
+    public bool addToCart(int userId, int productId, int amount)
     {
-      return _cartEngine.addToCart(cartId, product, amount);
+      return _cartEngine.addToCart(userId, productId, amount);
     }
 
-    public bool removeFromCart(int cartId, Product product)
+    public bool removeFromCart(int userId, int productId)
     {
-      return _cartEngine.removeFromCart(cartId, product);
+      return _cartEngine.removeFromCart(userId, productId);
     }
 
-    public bool updateAmount(int cartId, Product product, int amount)
+    public bool updateAmount(int userId, int productId, int amount)
     {
-      return _cartEngine.updateAmount(cartId, product, amount);
+      return _cartEngine.updateAmount(userId, productId, amount);
     }
 
     public bool initiateCart(Cart cart)
@@ -38,9 +38,9 @@ namespace CombinedAPI.Services
       return _cartEngine.initiateCart(cart);
     }
 
-    public bool clearCart(int cartId)
+    public bool clearCart(int userId)
     {
-      return _cartEngine.clearCart(cartId);
+      return _cartEngine.clearCart(userId);
     }
   }
 }


### PR DESCRIPTION
**Summary**

- This Pull goes through each Cart layer and fixes the SQL queries to coincide with the SQL database to fix null queries.
- Changes the input for most changes to require userID instead of cartID, since the frontend has no convenient way to get the cartID outside of creating the cart.
- When getting the User's cart, will grab and update the price to coincide with the products currently in the cart.
- If addToCart is called with the product already in the cart, it will now update the amount currently in it instead of adding a new instance to the itemList
- These functions have been tested to ensure they work through the API and seem to fully function correctly

**Known Issue**

- Specific queries which require the cartID to be inputted to keep the user's cart together is returned with an error stating that "'Cannot insert explicit value for identity column in table 'CheckoutCart' when IDENTITY_INSERT is set to OFF.'", which requires the database permissions to be updated I believe